### PR TITLE
added function to clear pickers

### DIFF
--- a/app/src/main/java/me/jfenn/colorpickerdialogsample/MainActivity.java
+++ b/app/src/main/java/me/jfenn/colorpickerdialogsample/MainActivity.java
@@ -8,9 +8,11 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
+
 import me.jfenn.colorpickerdialog.dialogs.ColorPickerDialog;
 import me.jfenn.colorpickerdialog.interfaces.OnColorPickedListener;
 import me.jfenn.colorpickerdialog.views.picker.ImagePickerView;
+import me.jfenn.colorpickerdialog.views.picker.RGBPickerView;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener, OnColorPickedListener<ColorPickerDialog> {
 
@@ -38,7 +40,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 .withTitle("Example Color Picker")
                 .withCornerRadius(16)
                 .withAlphaEnabled(v.getId() != R.id.normal)
+                .clearPickers()
                 .withPresets(v.getId() == R.id.normalAlpha ? new int[]{0, 0x50ffffff, 0x50000000} : new int[]{})
+                .withPicker(RGBPickerView.class)
                 .withPicker(ImagePickerView.class)
                 .withTheme(v.getId() == R.id.dark ? R.style.ColorPickerDialog_Dark : R.style.ColorPickerDialog)
                 .withListener(this)

--- a/base/src/main/java/me/jfenn/colorpickerdialog/dialogs/ColorPickerDialog.java
+++ b/base/src/main/java/me/jfenn/colorpickerdialog/dialogs/ColorPickerDialog.java
@@ -12,17 +12,18 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.google.android.material.tabs.TabLayout;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.view.ContextThemeWrapper;
 import androidx.appcompat.widget.AppCompatEditText;
 import androidx.viewpager.widget.ViewPager;
+
+import com.google.android.material.tabs.TabLayout;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
 import me.jfenn.colorpickerdialog.R;
 import me.jfenn.colorpickerdialog.adapters.ColorPickerPagerAdapter;
 import me.jfenn.colorpickerdialog.utils.ArrayUtils;
@@ -126,8 +127,8 @@ public class ColorPickerDialog extends PickerDialog<ColorPickerDialog> {
      * Specify whether alpha values should be enabled. This parameter
      * defaults to true.
      *
-     * @param isAlphaEnabled    Whether alpha values are enabled.
-     * @return                  "This" dialog instance, for method chaining.
+     * @param isAlphaEnabled Whether alpha values are enabled.
+     * @return "This" dialog instance, for method chaining.
      */
     public ColorPickerDialog withAlphaEnabled(boolean isAlphaEnabled) {
         this.isAlphaEnabled = isAlphaEnabled;
@@ -138,8 +139,8 @@ public class ColorPickerDialog extends PickerDialog<ColorPickerDialog> {
      * Enables the preset picker view and applies the passed presets. Passing
      * nothing will enable the picker view with the default preset values.
      *
-     * @param presets           The preset colors to use.
-     * @return                  "This" dialog instance, for method chaining.
+     * @param presets The preset colors to use.
+     * @return "This" dialog instance, for method chaining.
      */
     public ColorPickerDialog withPresets(@ColorInt int... presets) {
         this.presets = presets;
@@ -163,12 +164,12 @@ public class ColorPickerDialog extends PickerDialog<ColorPickerDialog> {
      * Add an unidentified picker view to the dialog, if it doesn't already
      * exist. This class is instantiated by the dialog, to keep the view's
      * Context consistent with the rest of the styled components.
-     *
+     * <p>
      * If the picker view already exists in the dialog, this will throw an
      * error.
      *
-     * @param pickerClass       The class of the picker view to add.
-     * @return                  "This" dialog instance, for method chaining.
+     * @param pickerClass The class of the picker view to add.
+     * @return "This" dialog instance, for method chaining.
      */
     public <T extends PickerView> ColorPickerDialog withPicker(Class<T> pickerClass) {
         DelayedInstantiation<T> picker = getPicker(pickerClass);
@@ -189,8 +190,8 @@ public class ColorPickerDialog extends PickerDialog<ColorPickerDialog> {
      * Determine whether a particular picker view is enabled, and return
      * it. If not, this will return null.
      *
-     * @param pickerClass       The class of the PickerView.
-     * @return                  The view, if it is enabled; null if not.
+     * @param pickerClass The class of the PickerView.
+     * @return The view, if it is enabled; null if not.
      */
     @Nullable
     public <T extends PickerView> DelayedInstantiation<T> getPicker(Class<T> pickerClass) {
@@ -206,8 +207,8 @@ public class ColorPickerDialog extends PickerDialog<ColorPickerDialog> {
      * Set the picker views used by the dialog. If this method is called with
      * no arguments, the default pickers will be used; an RGB and HSV picker.
      *
-     * @param pickers           The picker views to use.
-     * @return                  "This" dialog instance, for method chaining.
+     * @param pickers The picker views to use.
+     * @return "This" dialog instance, for method chaining.
      */
     public ColorPickerDialog withPickers(Class... pickers) {
         if (pickers.length == 0) {
@@ -222,6 +223,19 @@ public class ColorPickerDialog extends PickerDialog<ColorPickerDialog> {
             }
         }
 
+        return this;
+    }
+
+    /**
+     * Clears the picker views used by dialog.
+     * This is a workaround, if you want to show the presets tab as first tab
+     * you can use withPickers(), but then you use the default colors, not the ones you've set.
+     * @see #withPickers
+     *
+     * @return "This" dialog instance, for method chaining.
+     */
+    public ColorPickerDialog clearPickers() {
+        this.pickers = new DelayedInstantiation[0];
         return this;
     }
 


### PR DESCRIPTION
If I want to show the presets tab as first tab I can use withPickers(), but then I use the default colors, not the ones I have set before.
Now with clearPickers, I can set the order of the tabs, as I like it.
Like this:
` new ColorPickerDialog()
                .withColor(color)
                .withAlphaEnabled(v.getId() != R.id.normal)
                .clearPickers()
                .withPresets(new int[]{0, 0x50ffffff, 0x50000000})
                .withPicker(RGBPickerView.class)
                .withPicker(ImagePickerView.class)
                .withListener(this)
                .show(getSupportFragmentManager(), "aaa");`